### PR TITLE
Change the name of the frontmatter param;

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ date: 2020-08-25
 ---
 ```
 
-To add a background image to the header of the article the frontmatter must have `bigimg` set with the url of a photo. To add a thumbnail that shows in the list of articles, `image` must be added.
+To add a background image to the header of the article the frontmatter must have `bigimg` set with the url of a photo. To add a thumbnail that shows in the list of articles, `thumb_image` must be added.
 For example:
 
 ```
@@ -319,7 +319,7 @@ title: My Covid-19 post
 subtitle: By Ana
 date: 2020-08-25
 bigimg: /img/montage_smwp.png
-image: /img/montage_smwp.png
+thumb_image: /img/montage_smwp.png
 ---
 ```
 

--- a/_covid19/2020-10-06-test-run-covid-2.md
+++ b/_covid19/2020-10-06-test-run-covid-2.md
@@ -4,7 +4,7 @@
 # subtitle: By Aaron
 # date: 2020-10-06
 # bigimg: /img/posts_usa.png
-# image: /img/posts_usa.png
+# thumb_image: /img/posts_usa.png
 # ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec bibendum vestibulum mauris, id hendrerit tellus pulvinar nec. Sed vulputate, arcu quis sagittis consectetur, magna nisl ultrices ex, eget pellentesque leo risus in ipsum. Nunc cursus risus id lectus rhoncus rhoncus. In ut lorem id sem faucibus semper. Nunc ac mollis velit. Proin quis turpis nisl. Ut finibus accumsan velit, non dignissim nisi vestibulum non. Nullam aliquet eget tellus non placerat. Vivamus euismod ultricies varius. Mauris odio mauris, blandit in nibh ut, luctus interdum leo. Integer dui metus, dapibus vitae lacus vitae, auctor aliquet justo. Nam gravida imperdiet nunc in congue. Curabitur tincidunt nisl vitae efficitur pharetra.

--- a/_covid19/necropolitics-racial-arithmetic.md
+++ b/_covid19/necropolitics-racial-arithmetic.md
@@ -4,7 +4,7 @@ title: Government Data Practices as Necropolitics and Racial Arithmetic
 subtitle: By Rashida Richardson
 date: 2020-10-08
 bigimg: /img/posts_usa.png
-image: /img/posts_usa.png
+thumb_image: /img/posts_usa.png
 ---
 
 Essay #1 in the **_Data and Pandemic Politics_** series on data justice and COVID-19

--- a/_layouts/covid-19.html
+++ b/_layouts/covid-19.html
@@ -27,10 +27,10 @@ layout: base
             </p>
 
             <div class="post-entry-container">
-              {% if post.image %}
+              {% if post.thumb_image %}
               <div class="post-image">
                 <a href="{{ post.url | prepend: site.baseurl }}">
-                  <img src="{{ post.image }}">
+                  <img src="{{ post.thumb_image }}">
                 </a>
               </div>
               {% endif %}


### PR DESCRIPTION
Change the name of the frontmatter param for post thumbnails in the COVID-19 section so that it doesn't override the main navigation image;